### PR TITLE
Fix undefined typed property

### DIFF
--- a/src/Handler/MonologRotatingFileHandler.php
+++ b/src/Handler/MonologRotatingFileHandler.php
@@ -15,7 +15,7 @@ class MonologRotatingFileHandler extends StreamHandler
     protected string $filename;
     protected int $maxFiles;
     protected int $maxFileSize;
-    protected bool $mustRotate;
+    protected bool $mustRotate = false;
 
     /**
      * @param string $filename


### PR DESCRIPTION
Fix: Uncaught Error: Typed property sgoettsch\MonologRotatingFileHandler\Handler\MonologRotatingFileHandler::$mustRotate must not be accessed before initialization in src/Handler/MonologRotatingFileHandler.php:61